### PR TITLE
Update variables.tf

### DIFF
--- a/modules/azure-oracle-adbs/variables.tf
+++ b/modules/azure-oracle-adbs/variables.tf
@@ -48,7 +48,7 @@ variable "db_ecpu_count" {
 variable "db_storage_in_tbs" {
   type        = number
   description = "Size, in terrabyte, of the data volume that will be created and attached to the database"
-  default     = 20
+  default     = 1
 }
 variable "db_version" {
   type        = string


### PR DESCRIPTION
Update default storage to 1 TB instead of 20 TB.
The default storage size was 20 for db_storage_in_**g**bs and the value maintain the same when the variable was updated to db_storage_in_**t**bs.